### PR TITLE
Feat/#9 order domain create

### DIFF
--- a/src/main/java/com/usinsa/backend/domain/order/controller/OrderController.java
+++ b/src/main/java/com/usinsa/backend/domain/order/controller/OrderController.java
@@ -1,0 +1,30 @@
+package com.usinsa.backend.domain.order.controller;
+
+import com.usinsa.backend.domain.order.entity.Order;
+import com.usinsa.backend.domain.order.service.OrderService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/orders")
+@RequiredArgsConstructor
+public class OrderController {
+
+    private final OrderService orderService;
+
+    @PostMapping
+    public ResponseEntity<Order> createOrder(@RequestBody Order order) {
+        return ResponseEntity.ok(orderService.createOrder(order));
+    }
+
+    @PutMapping("/{orderId}")
+    public ResponseEntity<Order> updateOrder(@PathVariable Long orderId, @RequestBody Order order) {
+        return ResponseEntity.ok(orderService.updateOrder(orderId, order));
+    }
+
+    @PostMapping("/{orderId}/cancel")
+    public ResponseEntity<Order> cancelOrder(@PathVariable Long orderId) {
+        return ResponseEntity.ok(orderService.cancelOrder(orderId));
+    }
+}

--- a/src/main/java/com/usinsa/backend/domain/order/entity/Order.java
+++ b/src/main/java/com/usinsa/backend/domain/order/entity/Order.java
@@ -1,0 +1,38 @@
+package com.usinsa.backend.domain.order.entity;
+
+import com.usinsa.backend.domain.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "`order`") // order -> 예약어
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Order {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "order_id")
+    private Long id;
+
+    // 비회원 주문 가능시 optional = true
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(nullable = false)
+    private String receiverAddress;
+
+    @Column(nullable = false)
+    private String receiverName;
+
+    @Column(nullable = false)
+    private String receiverPhone;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private OrderStatus status;
+}

--- a/src/main/java/com/usinsa/backend/domain/order/entity/OrderStatus.java
+++ b/src/main/java/com/usinsa/backend/domain/order/entity/OrderStatus.java
@@ -1,0 +1,6 @@
+package com.usinsa.backend.domain.order.entity;
+
+public enum OrderStatus {
+    CREATED,   // 생성됨
+    CANCELLED  // 취소됨
+}

--- a/src/main/java/com/usinsa/backend/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/usinsa/backend/domain/order/repository/OrderRepository.java
@@ -1,0 +1,7 @@
+package com.usinsa.backend.domain.order.repository;
+
+import com.usinsa.backend.domain.order.entity.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+}

--- a/src/main/java/com/usinsa/backend/domain/order/service/OrderService.java
+++ b/src/main/java/com/usinsa/backend/domain/order/service/OrderService.java
@@ -1,0 +1,45 @@
+package com.usinsa.backend.domain.order.service;
+
+import com.usinsa.backend.domain.order.entity.Order;
+import com.usinsa.backend.domain.order.entity.OrderStatus;
+import com.usinsa.backend.domain.order.repository.OrderRepository;
+import org.springframework.stereotype.Service;
+import lombok.*;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class OrderService {
+
+    private final OrderRepository orderRepository;
+
+    // 주문 생성
+    @Transactional
+    public Order createOrder(Order order) {
+        order.setStatus(OrderStatus.CREATED);
+        return orderRepository.save(order);
+    }
+
+    // 주문 수정
+    @Transactional
+    public Order updateOrder(Long orderId, Order updatedOrder) {
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new IllegalArgumentException("Order not found"));
+
+        order.setReceiverAddress(updatedOrder.getReceiverAddress());
+        order.setReceiverName(updatedOrder.getReceiverName());
+        order.setReceiverPhone(updatedOrder.getReceiverPhone());
+
+        return order;
+    }
+
+    // 주문 취소
+    @Transactional
+    public Order cancelOrder(Long orderId) {
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new IllegalArgumentException("Order not found"));
+
+        order.setStatus(OrderStatus.CANCELLED);
+        return order;
+    }
+}


### PR DESCRIPTION
Entity

- Order 엔티티 설계 (@builder, @NoArgsConstructor 등 적용)
- OrderStatus 주문 상태 저장을 위한 ENUM 추가


Repository

- OrderRepository 작성 (JpaRepository 상속)

Service

- 기본 CRUD 작성
- 주문 생성 - createOrder
- 주문 수정 - updateOrder
- 주문 삭제 - cancelOrder

Controller

- 기본 CRUD 작성